### PR TITLE
website: Set up CloudFront aliases

### DIFF
--- a/website/serverless.ts
+++ b/website/serverless.ts
@@ -73,6 +73,7 @@ const serverlessConfiguration: AWS = {
         Type: "AWS::CloudFront::Distribution",
         Properties: {
           DistributionConfig: {
+            Aliases: [env.CUSTOM_DOMAIN],
             Comment: S3_BUCKET_NAME,
             DefaultCacheBehavior: {
               AllowedMethods: ["GET", "HEAD"],
@@ -119,7 +120,9 @@ const serverlessConfiguration: AWS = {
             }],
             PriceClass: "PriceClass_100",
             ViewerCertificate: {
-              CloudFrontDefaultCertificate: true,
+              AcmCertificateArn: "arn:aws:acm:us-east-1:338337944728:certificate/1da4e440-ec4c-4d8f-8ec6-b1b85969d360",
+              MinimumProtocolVersion: "TLSv1.2_2021",
+              SslSupportMethod: "sni-only",
             },
           },
         },

--- a/website/src/env/dev.ts
+++ b/website/src/env/dev.ts
@@ -3,6 +3,8 @@ import type { Env } from "../helpers/types"
 const env: Env = {
   STAGE: "dev",
 
+  CUSTOM_DOMAIN: "dev.joinraise.org",
+
   API_BASE_URL: "https://bblp6lj50j.execute-api.eu-west-1.amazonaws.com",
 
   // OAuth 2 client id for Google sign-in

--- a/website/src/env/local.template.ts
+++ b/website/src/env/local.template.ts
@@ -3,6 +3,8 @@ import type { Env } from "../helpers/types"
 const env: Env = {
   STAGE: "local",
 
+  CUSTOM_DOMAIN: "not used",
+
   API_BASE_URL: "http://localhost:8001",
 
   // OAuth 2 client id for Google sign-in

--- a/website/src/env/prod.ts
+++ b/website/src/env/prod.ts
@@ -3,6 +3,8 @@ import type { Env } from "../helpers/types"
 const env: Env = {
   STAGE: "prod",
 
+  CUSTOM_DOMAIN: "www.joinraise.org",
+
   API_BASE_URL: "https://5kh7xzkn5m.execute-api.eu-west-1.amazonaws.com",
 
   // OAuth 2 client id for Google sign-in

--- a/website/src/helpers/types.ts
+++ b/website/src/helpers/types.ts
@@ -1,6 +1,8 @@
 export interface Env {
   STAGE: string,
 
+  CUSTOM_DOMAIN: string,
+
   API_BASE_URL: string,
 
   GOOGLE_CLIENT_ID: string,


### PR DESCRIPTION
This is so people can access the website at `www.joinraise.org` and `dev.joinraise.org` (rather than `something.cloudfront.com`)

Related docs:
- https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html
- https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-https-alternate-domain-names.html

The ARN is an ACM certificate I've set up and verified manually by updating DNS records. It covers `*.joinraise.org` and `joinraise.org`.