### PR TITLE
Set default charity when creating a new donation to 'Unknown'

### DIFF
--- a/server/src/api/admin/fundraisers/{fundraiserId}/donations/post.ts
+++ b/server/src/api/admin/fundraisers/{fundraiserId}/donations/post.ts
@@ -45,7 +45,7 @@ export const main = middyfy($DonationCreation, $Ulid, true, async (event) => {
     recurrenceFrequency: event.body.recurrenceFrequency ?? null,
     stripeCustomerId: event.body.stripeCustomerId ?? null,
     stripePaymentMethodId: event.body.stripePaymentMethodId ?? null,
-    charity: event.body.charity ?? "AMF",
+    charity: event.body.charity ?? "Unknown",
     overallPublic: event.body.overallPublic ?? false,
     namePublic: event.body.namePublic ?? false,
     donationAmountPublic: event.body.donationAmountPublic ?? false,

--- a/website/src/pages/admin/fundraiser.tsx
+++ b/website/src/pages/admin/fundraiser.tsx
@@ -238,7 +238,7 @@ const DonationsSummaryView: React.FC<{ fundraiserId: string, fundraiser?: Fundra
             addressCountry: null,
             giftAid: false,
             comment: null,
-            charity: "AMF",
+            charity: "Unknown",
             overallPublic: false,
             namePublic: false,
             donationAmountPublic: false,


### PR DESCRIPTION
Avoids donations being accidentally manually entered as AMF, when actually they're not.