### PR TITLE
Improve prominence of red CTA button on mobile

### DIFF
--- a/web/src/components/Navigation.tsx
+++ b/web/src/components/Navigation.tsx
@@ -15,44 +15,25 @@ const Navigation: React.FC<{ left: Link[], right: Link[] }> = ({ left, right }) 
     <nav className={classNames("text-3xl md:text-xl lg:text-2xl md:bg-transparent", { "bg-raise-purple": open })}>
       <Disclosure open={open} onChange={() => setOpen(!open)}>
         <SectionNoPadding>
-          <div className="relative flex items-center justify-between h-20 w-16 md:w-auto py-4">
-            <div className="flex items-center md:hidden">
-              <DisclosureButton className="inline-flex items-center justify-center p-2 rounded focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
-                <span className="sr-only">Open main menu</span>
-                {open ? (
-                  <XIcon className="block h-10 w-10" aria-hidden="true" />
-                ) : (
-                  <MenuIcon className="block h-10 w-10" aria-hidden="true" />
-                )}
-              </DisclosureButton>
-            </div>
-            <div className="flex-1 flex items-center justify-center md:items-stretch md:justify-start">
-              <div className="hidden md:block">
-                <div className="flex space-x-2">
-                  {left.map((item, i) => (
-                    <Link
-                      key={item.text}
-                      href={item.href}
-                      onClick={item.onClick}
-                      className={classNames("hover:text-gray-100 transform transition-all duration-250 scale-100 hover:scale-105 p-2", { "pl-0": i === 0 })}
-                    >
-                      {item.text}
-                    </Link>
-                  ))}
-                </div>
-              </div>
-            </div>
-            <div className="absolute inset-y-0 right-0 flex items-center pr-2 md:static md:inset-auto md:ml-6 md:pr-0">
-              <div className="hidden md:block">
-                <div className="flex space-x-2">
-                  {right.map((item) => (
-                    <Button key={item.text} href={item.href} onClick={item.onClick} variant="red">{item.text}</Button>
-                  ))}
-                </div>
-              </div>
-            </div>
+          {/* Mobile nav: menu button */}
+          <div className="text-left pt-4 md:hidden">
+            <DisclosureButton className="p-2 rounded outline-none focus:ring-2 focus:ring-white" aria-label={open ? "Close main menu" : "Open main menu"}>
+              {open ? (
+                <XIcon className="block h-8 w-8" />
+              ) : (
+                <MenuIcon className="block h-8 w-8" />
+              )}
+            </DisclosureButton>
           </div>
 
+          {/* Mobile nav: (optional) singular right button */}
+          {!open && right.length === 1 && (
+            <div className="md:hidden ml-16 -mt-[3.25rem] mr-2 mb-4 text-right text-2xl">
+              <Button key={right[0].text} href={right[0].href} onClick={right[0].onClick} variant="red">{right[0].text}</Button>
+            </div>
+          )}
+
+          {/* Mobile nav: menu contents */}
           <DisclosurePanel className="md:hidden">
             <div className="px-8 -mt-12 pb-8 space-y-2">
               {left.map((item) => (
@@ -70,6 +51,35 @@ const Navigation: React.FC<{ left: Link[], right: Link[] }> = ({ left, right }) 
               ))}
             </div>
           </DisclosurePanel>
+
+          {/* Desktop nav */}
+          <div className="hidden md:flex py-4">
+            <div className="flex-1 flex items-center justify-center md:items-stretch md:justify-start">
+              <div>
+                <div className="flex space-x-2">
+                  {left.map((item, i) => (
+                    <Link
+                      key={item.text}
+                      href={item.href}
+                      onClick={item.onClick}
+                      className={classNames("hover:text-gray-100 transform transition-all duration-250 scale-100 hover:scale-105 p-2", { "pl-0": i === 0 })}
+                    >
+                      {item.text}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            </div>
+            <div className="absolute inset-y-0 right-0 flex items-center pr-2 md:static md:inset-auto md:ml-6 md:pr-0">
+              <div>
+                <div className="flex space-x-2">
+                  {right.map((item) => (
+                    <Button key={item.text} href={item.href} onClick={item.onClick} variant="red">{item.text}</Button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
         </SectionNoPadding>
       </Disclosure>
     </nav>


### PR DESCRIPTION
If there is a single 'right' button in the navigation, it is displayed on mobile without expanding the menu.

This commit also contains some minor refactoring to the navigation to make it easier to maintain, including splitting it into commented logical pieces and removing a load of (hopefully) unnecessary CSS.