### PR TITLE
Fix edge-case networking bug

### DIFF
--- a/web/src/helpers/networking.ts
+++ b/web/src/helpers/networking.ts
@@ -105,7 +105,7 @@ type UseReqCoreResult<
     ...Params extends null ? [] : [params: Params],
     ...RequestData extends null ? [] : [data: RequestData],
   ]
-  > = [
+> = [
     ResponseValues<Result, RequestData, ErrorResult>,
     (...args: RefetchArgs) => Promise<AxiosResponse<Result>>
   ]
@@ -140,11 +140,11 @@ export const useManualReq = <
   Params extends Routes[Route]["params"],
   Result extends Routes[Route]["response"],
   ErrorResult = unknown,
-  >(
+>(
     route: Route,
     ...argArr: [
-      ...[options?: UseReqOptions & { manual: true }]
-    ]
+    ...[options?: UseReqOptions & { manual: true }]
+  ]
   ): UseManualReqResult<Route, RequestData, Params, Result, ErrorResult> => useReqCore(route, { options: { ...argArr[0], manual: true } })
 
 export const useReq = <
@@ -153,13 +153,13 @@ export const useReq = <
   Params extends Routes[Route]["params"],
   Result extends Routes[Route]["response"],
   ErrorResult = unknown,
-  >(
+>(
     route: Route,
     ...argArr: [
-      ...Params extends null ? [] : [params: Params],
-      ...RequestData extends null ? [] : [data: RequestData],
-      ...[options?: UseReqOptions]
-    ]
+    ...Params extends null ? [] : [params: Params],
+    ...RequestData extends null ? [] : [data: RequestData],
+    ...[options?: UseReqOptions]
+  ]
   ): UseReqResult<Route, RequestData, Params, Result, ErrorResult> => useReqCore(route, convertArgsToObj(routes[route], argArr))
 
 const useReqCore = <
@@ -168,11 +168,11 @@ const useReqCore = <
   Params extends Routes[Route]["params"],
   Result extends Routes[Route]["response"],
   ErrorResult = unknown,
-  >(route: Route, args: {
-    params?: Params extends null ? Record<string, never> : Params,
-    data?: RequestData extends null ? undefined : RequestData,
-    options: UseReqOptions,
-  }): UseReqCoreResult<Route, RequestData, Params, Result, ErrorResult> => {
+>(route: Route, args: {
+  params?: Params extends null ? Record<string, never> : Params,
+  data?: RequestData extends null ? undefined : RequestData,
+  options: UseReqOptions,
+}): UseReqCoreResult<Route, RequestData, Params, Result, ErrorResult> => {
   // Hack for Gatsby SSR so that dynamic components appear to be loading
   if (typeof window === "undefined") {
     return [{
@@ -185,7 +185,7 @@ const useReqCore = <
   const config: AxiosRequestConfig<RequestData> = {
     method: routes[route].method,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    url: routes[route].makePath(args.params as any),
+    url: args.params ? routes[route].makePath(args.params as any) : undefined,
     data: args.data,
     ...(auth?.token ? {
       headers: {
@@ -210,8 +210,8 @@ const useReqCore = <
       ...config,
       ...(overrideArgs ? {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        url: routes[route].makePath(args.params as any),
-        data: args.data,
+        url: routes[route].makePath(overrideArgs.params as any),
+        data: overrideArgs.data,
       } : undefined),
       ...(bypassCache ? {
         cache: {

--- a/web/src/helpers/networking.ts
+++ b/web/src/helpers/networking.ts
@@ -143,8 +143,8 @@ export const useManualReq = <
 >(
     route: Route,
     ...argArr: [
-    ...[options?: UseReqOptions & { manual: true }]
-  ]
+      ...[options?: UseReqOptions & { manual: true }]
+    ]
   ): UseManualReqResult<Route, RequestData, Params, Result, ErrorResult> => useReqCore(route, { options: { ...argArr[0], manual: true } })
 
 export const useReq = <
@@ -156,10 +156,10 @@ export const useReq = <
 >(
     route: Route,
     ...argArr: [
-    ...Params extends null ? [] : [params: Params],
-    ...RequestData extends null ? [] : [data: RequestData],
-    ...[options?: UseReqOptions]
-  ]
+      ...Params extends null ? [] : [params: Params],
+      ...RequestData extends null ? [] : [data: RequestData],
+      ...[options?: UseReqOptions]
+    ]
   ): UseReqResult<Route, RequestData, Params, Result, ErrorResult> => useReqCore(route, convertArgsToObj(routes[route], argArr))
 
 const useReqCore = <


### PR DESCRIPTION
The custom override was not being applied correctly. In addition, when constructing the useReqCore we built the URL even if we didn't yet have the args. Both of these are now fixed.

Future work: We need tests here. We also need a better pattern for handling errors when manually calling useReq. Also, making the eslint rules less trigger happy about spacing when dealing with TypeScript would be nice (but similarly, we want to enforce some sensible spacing).