### PR TITLE
Wrap users panel in admin users page

### DIFF
--- a/apps/web/src/components/UsersPanel.tsx
+++ b/apps/web/src/components/UsersPanel.tsx
@@ -15,7 +15,7 @@ import { UserCreation } from '../helpers/generated-api-client';
 
 const UsersPanel: React.FC = () => {
   const [users, refetchUsers] = useReq('get /admin/users');
-  const [groups, refetchGroups] = useReq('get /admin/groups');
+  const [groups] = useReq('get /admin/groups');
   const groupMap = groups.data ? Object.fromEntries(groups.data.map((group) => [group.id, group.name])) : {};
   const [newUserModalOpen, setNewUserModalOpen] = useState(false);
   const req = useRawReq();

--- a/apps/web/src/components/UsersPanel.tsx
+++ b/apps/web/src/components/UsersPanel.tsx
@@ -1,0 +1,77 @@
+import { navigate } from 'gatsby';
+import { PlusSmIcon } from '@heroicons/react/outline';
+import { fixedGroups, format } from '@raise/shared';
+import { useState } from 'react';
+import {
+  asResponseValues, useReq, useRawReq,
+} from '../helpers/networking';
+import Section, { SectionTitle } from './Section';
+import Table from './Table';
+import Button from './Button';
+import Modal from './Modal';
+import { Form } from './Form';
+import { RequireGroup } from '../helpers/security';
+import { UserCreation } from '../helpers/generated-api-client';
+
+const UsersPanel: React.FC = () => {
+  const [users, refetchUsers] = useReq('get /admin/users');
+  const [groups, refetchGroups] = useReq('get /admin/groups');
+  const groupMap = groups.data ? Object.fromEntries(groups.data.map((group) => [group.id, group.name])) : {};
+  const [newUserModalOpen, setNewUserModalOpen] = useState(false);
+  const req = useRawReq();
+
+  return (
+    <Section>
+      <div className="flex">
+        <SectionTitle className="flex-1">Users</SectionTitle>
+        <RequireGroup group={fixedGroups.National}>
+          <Button onClick={() => setNewUserModalOpen(true)}>
+            <PlusSmIcon className="h-6 mb-1" />
+            {' '}
+            New
+            {' '}
+            <span className="hidden lg:inline">user</span>
+          </Button>
+        </RequireGroup>
+      </div>
+      <Modal open={newUserModalOpen} onClose={() => setNewUserModalOpen(false)}>
+        <Form<UserCreation>
+          title="New user"
+          definition={{
+            name: { label: 'Name', inputType: 'text' },
+            email: { label: 'Email', inputType: 'text' },
+            groups: {
+              label: 'Groups', formatter: (ids?: string[]) => ids?.map((id) => groupMap[id]).join(', ') || '(none)', inputType: 'multiselect', selectOptions: groupMap,
+            },
+            securityTrainingCompletedAt: { label: 'Security training completed at', formatter: format.timestamp, inputType: 'datetime-local' },
+          }}
+          initialValues={{
+            name: '',
+            email: '',
+            groups: [],
+            securityTrainingCompletedAt: Math.floor(new Date().getTime() / 1000),
+          }}
+          showCurrent={false}
+          onSubmit={async (data) => {
+            const userId = (await req('post /admin/users', data)).data;
+            await refetchUsers();
+            navigate(`/admin/users/${userId}/`);
+          }}
+        />
+      </Modal>
+      <Table
+        className="mb-8"
+        definition={{
+          name: { label: 'Name', className: 'whitespace-nowrap' },
+          email: { label: 'Email', className: 'whitespace-nowrap' },
+          groups: { label: 'Groups', formatter: (ids?: string[]) => ids?.map((id) => groupMap[id]).join(', ') || '(none)' },
+        }}
+            // eslint-disable-next-line no-nested-ternary
+        items={asResponseValues(users.data?.sort((a, b) => (a.name === b.name ? 0 : (a.name > b.name ? 1 : -1))), users)}
+        onClick={(user) => navigate(`/admin/users/${user.id}/`)}
+      />
+    </Section>
+  );
+};
+
+export default UsersPanel;

--- a/apps/web/src/pages/admin/users.tsx
+++ b/apps/web/src/pages/admin/users.tsx
@@ -1,7 +1,7 @@
 import { RouteComponentProps } from '@gatsbyjs/reach-router';
 import { navigate } from 'gatsby';
 import { PlusSmIcon } from '@heroicons/react/outline';
-import { fixedGroups, format } from '@raise/shared';
+import { fixedGroups } from '@raise/shared';
 import { useState } from 'react';
 import {
   asResponseValues, useReq, useRawReq,
@@ -13,69 +13,20 @@ import Modal from '../../components/Modal';
 import { Form } from '../../components/Form';
 import { RequireGroup } from '../../helpers/security';
 import {
-  GroupCreation, UserCreation,
+  GroupCreation,
 } from '../../helpers/generated-api-client';
+import UsersPanel from '../../components/UsersPanel';
 
 const UsersPage: React.FC<RouteComponentProps> = () => {
-  const [users, refetchUsers] = useReq('get /admin/users');
   const [groups, refetchGroups] = useReq('get /admin/groups');
-  const groupMap = groups.data ? Object.fromEntries(groups.data.map((group) => [group.id, group.name])) : {};
-  const [newUserModalOpen, setNewUserModalOpen] = useState(false);
   const [newGroupModalOpen, setNewGroupModalOpen] = useState(false);
   const req = useRawReq();
 
   return (
     <>
-      <Section>
-        <div className="flex">
-          <SectionTitle className="flex-1">Users</SectionTitle>
-          <RequireGroup group={fixedGroups.National}>
-            <Button onClick={() => setNewUserModalOpen(true)}>
-              <PlusSmIcon className="h-6 mb-1" />
-              {' '}
-              New
-              {' '}
-              <span className="hidden lg:inline">user</span>
-            </Button>
-          </RequireGroup>
-        </div>
-        <Modal open={newUserModalOpen} onClose={() => setNewUserModalOpen(false)}>
-          <Form<UserCreation>
-            title="New user"
-            definition={{
-              name: { label: 'Name', inputType: 'text' },
-              email: { label: 'Email', inputType: 'text' },
-              groups: {
-                label: 'Groups', formatter: (ids?: string[]) => ids?.map((id) => groupMap[id]).join(', ') || '(none)', inputType: 'multiselect', selectOptions: groupMap,
-              },
-              securityTrainingCompletedAt: { label: 'Security training completed at', formatter: format.timestamp, inputType: 'datetime-local' },
-            }}
-            initialValues={{
-              name: '',
-              email: '',
-              groups: [],
-              securityTrainingCompletedAt: Math.floor(new Date().getTime() / 1000),
-            }}
-            showCurrent={false}
-            onSubmit={async (data) => {
-              const userId = (await req('post /admin/users', data)).data;
-              await refetchUsers();
-              navigate(`/admin/users/${userId}/`);
-            }}
-          />
-        </Modal>
-        <Table
-          className="mb-8"
-          definition={{
-            name: { label: 'Name', className: 'whitespace-nowrap' },
-            email: { label: 'Email', className: 'whitespace-nowrap' },
-            groups: { label: 'Groups', formatter: (ids?: string[]) => ids?.map((id) => groupMap[id]).join(', ') || '(none)' },
-          }}
-          // eslint-disable-next-line no-nested-ternary
-          items={asResponseValues(users.data?.sort((a, b) => (a.name === b.name ? 0 : (a.name > b.name ? 1 : -1))), users)}
-          onClick={(user) => navigate(`/admin/users/${user.id}/`)}
-        />
-      </Section>
+      <RequireGroup group={fixedGroups.National}>
+        <UsersPanel />
+      </RequireGroup>
       <Section>
         <div className="flex">
           <SectionTitle className="flex-1">Groups</SectionTitle>


### PR DESCRIPTION
Created a new component to house the Users Panel, and it's states. 

Removed the old Users Panel, and replaced it with a self-closing tag with the new Users Panel component. This was then wrapped in RequireGroup so that the states within this component are only called when the user is part of the necessary group. This hence should solve the 403 alerts.

Also removed the various states/constants and now unnecessary imports from within Users.tsx