### PR TITLE
Removed renderHtml since it is present in footer()

### DIFF
--- a/apps/server/src/helpers/email/confirmation.ts
+++ b/apps/server/src/helpers/email/confirmation.ts
@@ -346,7 +346,7 @@ export default (fundraiser: Fundraiser, donation: Donation, payments: Payment[])
         </tbody>
       </table>
     </div>
-    ${renderHtml`${footer()}`}
+    ${footer()}
   </div>
 </body>
 


### PR DESCRIPTION
Removed renderHtml in confirmation email generation that would have otherwise rendered the footer, but the footer() function contains renderHtml and hence is not required in the confirmation email