### PR TITLE
Tidy get Task

### DIFF
--- a/apps/server/src/api/admin/tasks/get.test.ts
+++ b/apps/server/src/api/admin/tasks/get.test.ts
@@ -24,8 +24,8 @@ test('lists tasks', async () => {
 
   // we get back the tasks
   expect(response).toEqual([
-    { id: '01FQWY151AJ6TJJBT44MM2HNZ8', name: 'A task' },
-    { id: '01FQWY1BPYFF3KS7BY8B4NJJSC', name: 'Some other task' },
+    { id: '01FQWY151AJ6TJJBT44MM2HNZ8', name: 'A task', groups: [fixedGroups.National] },
+    { id: '01FQWY1BPYFF3KS7BY8B4NJJSC', name: 'Some other task', groups: [fixedGroups.National] },
   ]);
   // nothing should have been run
   tasks.forEach((t) => expect(t.run).not.toHaveBeenCalled());

--- a/apps/server/src/api/admin/tasks/get.ts
+++ b/apps/server/src/api/admin/tasks/get.ts
@@ -1,15 +1,10 @@
 import { middyfy } from '../../../helpers/wrapper';
-import { $Tasks, Task } from '../../../schemas';
+import { $Tasks } from '../../../schemas';
 import tasks from '../../../tasks';
 
 export const main = middyfy(null, $Tasks, true, async (event) => {
   const overlap = (a: string[], b: string[]): boolean => a.some((v) => b.includes(v));
   const listOfAllTasks = tasks.map((t) => ({ id: t.id, name: t.name, groups: t.groups }));
-  const listOfTasks: Task[] = [];
-  listOfAllTasks.forEach((task) => {
-    if (overlap(event.auth.payload.groups, task.groups)) {
-      listOfTasks.push(task);
-    }
-  });
-  return (listOfTasks.map((t) => ({ id: t.id, name: t.name })));
+
+  return (listOfAllTasks.filter((task) => overlap(event.auth.payload.groups, task.groups)));
 });

--- a/apps/server/src/schemas/jsonSchema.ts
+++ b/apps/server/src/schemas/jsonSchema.ts
@@ -443,6 +443,7 @@ export const $Task: JSONSchema<S.Task> = {
   properties: {
     id: $Ulid,
     name: { type: 'string' },
+    groups: { type: 'array', items: { type: 'string' } },
   },
   required: ['id', 'name'],
   additionalProperties: false,

--- a/apps/server/src/schemas/typescript.ts
+++ b/apps/server/src/schemas/typescript.ts
@@ -436,11 +436,13 @@ export interface StripeWebhookRequest {
 export interface Task {
   id: string;
   name: string;
+  groups?: string[];
 }
 
 export type Tasks = {
   id: string;
   name: string;
+  groups?: string[];
 }[];
 
 export interface GroupCreation {

--- a/apps/web/src/helpers/generated-api-client/types.ts
+++ b/apps/web/src/helpers/generated-api-client/types.ts
@@ -436,11 +436,13 @@ export interface StripeWebhookRequest {
 export interface Task {
   id: string;
   name: string;
+  groups?: string[];
 }
 
 export type Tasks = {
   id: string;
   name: string;
+  groups?: string[];
 }[];
 
 export interface GroupCreation {


### PR DESCRIPTION
Tidied up get.ts (for Tasks) by using .filter .

Also added a property, groups, to the object $Task which would remove the need for an extra line of code in get.ts that would otherwise remove the group property in the returned Tasks. Also, it made more sense to return the groups property too, should it be required in the future.