### PR TITLE
Update Sender Information

### DIFF
--- a/apps/server/src/api/admin/users/post.ts
+++ b/apps/server/src/api/admin/users/post.ts
@@ -17,13 +17,13 @@ export const main = middyfy($UserCreation, $Ulid, true, async (event) => {
   if (event.body.sendAccountCreationEmail === true) {
     // finds name of the logged in user who made the user. If for some reason, the user's name is undefined, it will use The Raise National Team instead
     const usersFromDb = await scan(userTable);
-    const sender: string = usersFromDb.find((u) => u.email === event.auth.payload.subject)?.name ?? 'The Raise National Team';
+    const sender: string = usersFromDb.find((u) => u.email === event.auth.payload.subject)?.name.concat(' (via Raise National)') ?? 'The Raise National Team';
 
     await sendEmail(
       'Your account has been created!',
       newUser(event.body, sender),
       event.body.email,
-      'Raise National',
+      sender,
     );
   }
 


### PR DESCRIPTION
Should the user creating the new user have a username (most probable scenario), it will add (via Raise National) at the end.