### PR TITLE
deploy archived property for fundraiser

### DIFF
--- a/apps/server/local/table_fundraiser.json
+++ b/apps/server/local/table_fundraiser.json
@@ -20,6 +20,7 @@
     "suggestedContributionAmount": 550,
     "eventLink": "https://example.com/event",
     "moreInvolvedLink": "https://example.com/more-involved",
+    "archived": false,
     "groupsWithAccess": [
       "01GPYGDJ19Z43X6S7YMK8AVSAH"
     ]

--- a/apps/server/local/testHelpers.ts
+++ b/apps/server/local/testHelpers.ts
@@ -99,6 +99,7 @@ export const makeFundraiser = <Override extends Partial<Fundraiser>>(override?: 
   suggestedContributionAmount: 10_00,
   eventLink: null,
   moreInvolvedLink: null,
+  archived: false,
   ...override,
 } as Fundraiser & Override)
 

--- a/apps/server/src/api/admin/fundraisers/post.ts
+++ b/apps/server/src/api/admin/fundraisers/post.ts
@@ -29,6 +29,7 @@ export const main = middyfy($FundraiserCreation, $Ulid, true, async (event) => {
     suggestedContributionAmount: event.body.suggestedContributionAmount ?? 10_00,
     eventLink: event.body.eventLink ?? null,
     moreInvolvedLink: event.body.moreInvolvedLink ?? null,
+    archived: event.body.archived ?? false,
     groupsWithAccess: event.body.groupsWithAccess ?? event.auth.payload.groups,
   });
 

--- a/apps/server/src/api/public/fundraisers/{fundraiserId}/donation/post.ts
+++ b/apps/server/src/api/public/fundraisers/{fundraiserId}/donation/post.ts
@@ -25,6 +25,11 @@ export const main = middyfy($PublicDonationRequest, $PublicPaymentIntentResponse
     throw new createHttpError.BadRequest('This fundraiser has temporarily paused taking donations');
   }
 
+  // Validate the fundraiser has not been archived
+  if (fundraiser.archived) {
+    throw new createHttpError.BadRequest('This fundraiser has been archived');
+  }
+
   // Validate gift-aid requirements
   if (event.body.giftAid) {
     if (!event.body.addressLine1) throw new createHttpError.BadRequest('Gift-aided donation must provide address line 1');

--- a/apps/server/src/api/public/fundraisers/{fundraiserId}/get.ts
+++ b/apps/server/src/api/public/fundraisers/{fundraiserId}/get.ts
@@ -29,6 +29,7 @@ export const main = middyfy(null, $PublicFundraiser, false, async (event) => {
     suggestedContributionAmount: fundraiser.suggestedContributionAmount,
     eventLink: fundraiser.eventLink,
     moreInvolvedLink: fundraiser.moreInvolvedLink,
+    archived: fundraiser.archived,
     donations: donations.filter((d) => d.overallPublic && d.donationCounted).map((d) => ({
       id: d.id,
       donorName: d.namePublic ? d.donorName : undefined,

--- a/apps/server/src/schemas/jsonSchema.ts
+++ b/apps/server/src/schemas/jsonSchema.ts
@@ -89,6 +89,7 @@ export const $FundraiserCreation: JSONSchema<S.FundraiserCreation> = {
     suggestedContributionAmount: { type: ['integer', 'null'], minimum: 0 },
     eventLink: { type: ['string', 'null'] },
     moreInvolvedLink: { type: ['string', 'null'] },
+    archived: { type: 'boolean' },
     // TODO: change to ulid once all groups migrated
     groupsWithAccess: { type: 'array', items: { type: 'string' } },
   },

--- a/apps/server/src/schemas/jsonSchema.ts
+++ b/apps/server/src/schemas/jsonSchema.ts
@@ -312,6 +312,7 @@ export const $PublicFundraiser: JSONSchema<S.PublicFundraiser> = {
     suggestedContributionAmount: { type: ['integer', 'null'], minimum: 0 },
     eventLink: { type: ['string', 'null'] },
     moreInvolvedLink: { type: ['string', 'null'] },
+    archived: { type: 'boolean' },
     donations: {
       type: 'array',
       items: {

--- a/apps/server/src/schemas/typescript.ts
+++ b/apps/server/src/schemas/typescript.ts
@@ -363,6 +363,7 @@ export interface PublicFundraiser {
   suggestedContributionAmount: number | null;
   eventLink: string | null;
   moreInvolvedLink: string | null;
+  archived?: boolean;
   donations: {
     id: string;
     donorName?: string;

--- a/apps/server/src/schemas/typescript.ts
+++ b/apps/server/src/schemas/typescript.ts
@@ -55,6 +55,7 @@ export interface FundraiserCreation {
   suggestedContributionAmount?: number | null;
   eventLink?: string | null;
   moreInvolvedLink?: string | null;
+  archived?: boolean;
   groupsWithAccess?: string[];
 }
 
@@ -78,6 +79,7 @@ export interface FundraiserEdits {
   suggestedContributionAmount?: number | null;
   eventLink?: string | null;
   moreInvolvedLink?: string | null;
+  archived?: boolean;
   groupsWithAccess?: string[];
   previous?: {
     totalRaised?: number;
@@ -106,6 +108,7 @@ export interface Fundraiser {
   suggestedContributionAmount: number | null;
   eventLink: string | null;
   moreInvolvedLink: string | null;
+  archived?: boolean;
   groupsWithAccess: string[];
 }
 
@@ -130,6 +133,7 @@ export type Fundraisers = {
   suggestedContributionAmount: number | null;
   eventLink: string | null;
   moreInvolvedLink: string | null;
+  archived?: boolean;
   groupsWithAccess: string[];
 }[];
 

--- a/apps/web/src/helpers/generated-api-client/types.ts
+++ b/apps/web/src/helpers/generated-api-client/types.ts
@@ -363,6 +363,7 @@ export interface PublicFundraiser {
   suggestedContributionAmount: number | null;
   eventLink: string | null;
   moreInvolvedLink: string | null;
+  archived?: boolean;
   donations: {
     id: string;
     donorName?: string;

--- a/apps/web/src/helpers/generated-api-client/types.ts
+++ b/apps/web/src/helpers/generated-api-client/types.ts
@@ -55,6 +55,7 @@ export interface FundraiserCreation {
   suggestedContributionAmount?: number | null;
   eventLink?: string | null;
   moreInvolvedLink?: string | null;
+  archived?: boolean;
   groupsWithAccess?: string[];
 }
 
@@ -78,6 +79,7 @@ export interface FundraiserEdits {
   suggestedContributionAmount?: number | null;
   eventLink?: string | null;
   moreInvolvedLink?: string | null;
+  archived?: boolean;
   groupsWithAccess?: string[];
   previous?: {
     totalRaised?: number;
@@ -106,6 +108,7 @@ export interface Fundraiser {
   suggestedContributionAmount: number | null;
   eventLink: string | null;
   moreInvolvedLink: string | null;
+  archived?: boolean;
   groupsWithAccess: string[];
 }
 
@@ -130,6 +133,7 @@ export type Fundraisers = {
   suggestedContributionAmount: number | null;
   eventLink: string | null;
   moreInvolvedLink: string | null;
+  archived?: boolean;
   groupsWithAccess: string[];
 }[];
 


### PR DESCRIPTION
Related to #313 

This should deploy the idea of the 'archived' property to the server, making sure that all new fundraisers have this property.

It is not yet a required property to prevent errors relating to older fundraisers not having this feature, which will be fixed in a future commit.