### PR TITLE
server: Fix error logging

### DIFF
--- a/apps/server/serverless.ts
+++ b/apps/server/serverless.ts
@@ -158,7 +158,7 @@ const serverlessConfiguration: AWS = {
       VERSION: getVersion(),
     },
     memorySize: 256,
-    timeout: 10,
+    timeout: 30,
     iam: {
       role: {
         statements: [

--- a/apps/server/webpack.config.js
+++ b/apps/server/webpack.config.js
@@ -2,13 +2,15 @@ const path = require("path")
 const slsw = require("serverless-webpack")
 const nodeExternals = require("webpack-node-externals")
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
+const { SourceMapDevToolPlugin } = require("webpack")
 
 /** @type { import('webpack').Configuration } */
 module.exports = {
   context: __dirname,
   mode: slsw.lib.webpack.isLocal ? "development" : "production",
   entry: slsw.lib.entries,
-  devtool: slsw.lib.webpack.isLocal ? "eval-cheap-module-source-map" : "source-map",
+  // See plugins below
+  devtool: slsw.lib.webpack.isLocal ? "eval-cheap-module-source-map" : undefined,
   resolve: {
     extensions: [".js", ".mjs", ".ts", ".json"],
     symlinks: false,
@@ -46,5 +48,17 @@ module.exports = {
       },
     ],
   },
-  plugins: [new ForkTsCheckerWebpackPlugin()],
+  plugins: [
+    ...(slsw.lib.webpack.isLocal ? [] : [new SourceMapDevToolPlugin({
+      filename: '[file].map',
+      // This line appears to help with being able to print stacktraces.
+      // Without this I think what is happening is:
+      // - We generate massive source maps because we include sources of deps (6 MB+)
+      // - We try accessing error.stack (or use a method which does this, like logging an error)
+      // - source-map-support means this file is then read, which hangs Node.js
+      // - Eventually the function times out and our server is sad - but doesn't alert us well
+      noSources: true,
+    })]),
+    new ForkTsCheckerWebpackPlugin(),
+  ],
 }


### PR DESCRIPTION
Previously we were generating source maps with all the original sources (including of deps). When generating stack traces this file was then read, which I think this was overwhelming our poor Lambda function.

The observed behavior looked like the AWS Lambda function hanging (eventually timing out on AWS API Gateway and returning 'Internal Server Error') when trying to console.log an error object, print a stacktrace, or access the error.stack property.

This PR fixes the problem by disabling including sources in our sourcemap. It still shows errors on the right file anyways (because it has the mappings, just not the sources - which weren't adding anything anyways). This seems to work, at least as a temporary solution. Am slightly worried what will happen if source map otherwise grows as errors can happen fairly silently :(