### PR TITLE
Updating fundraising numbers for 2024

### DIFF
--- a/apps/web/src/pages/cambridge/index.tsx
+++ b/apps/web/src/pages/cambridge/index.tsx
@@ -43,10 +43,10 @@ const IndexPage = () => (
           title="May Week Alternative"
           tagline="MWA is a charitable movement encouraging students to adopt a positive approach towards deliberate, effective giving."
           statistics={{
-            years: 4 + 1,
-            students: 1089 + 385,
-            raised: 228296 + 52735,
-            protected: 269737 + convert.moneyToPeopleProtected('gbp', 5273585),
+            years: 7,
+            students: 1755,
+            raised: 314767,
+            protected: 378337 + convert.moneyToPeopleProtected('gbp', 5273585),
           }}
         />
       </Section>


### PR DESCRIPTION
Have edited the numbers in accordance with Raise national statistics for Cambridge. Not sure if I've done the people protected bit right though, as was unsure about the gbp bit at the end! The initial number should be correct though.