### PR TITLE
Bring remaining chapters to parity with #457

### DIFF
--- a/apps/web/src/pages/bristol/index.tsx
+++ b/apps/web/src/pages/bristol/index.tsx
@@ -24,7 +24,7 @@ const IndexPage = () => (
 		<Cover>
 			<Navigation
 				left={[
-					{text: 'Home', href: '.'},
+					{text: 'Home', href: '/'},
 					{text: 'How It Works', href: '#how-it-works'},
 					{text: 'FAQs', href: '#faq'},
 					{text: 'Our Philosophy', href: '#our-philosophy'},

--- a/apps/web/src/pages/demo/index.tsx
+++ b/apps/web/src/pages/demo/index.tsx
@@ -23,7 +23,7 @@ const IndexPage = () => (
 		<Cover>
 			<Navigation
 				left={[
-					{text: 'Home', href: '/demo/'},
+					{text: 'Home', href: '/'},
 					{text: 'How It Works', href: '/demo/#how-it-works'},
 					{text: 'FAQs', href: '/demo/#faq'},
 					{text: 'Our Philosophy', href: '/demo/#our-philosophy'},

--- a/apps/web/src/pages/edinburgh/index.tsx
+++ b/apps/web/src/pages/edinburgh/index.tsx
@@ -33,7 +33,7 @@ const IndexPage = () => (
 				]}
 				right={[
 					{text: 'Donate', href: 'donate/'},
-					{text: 'Get Invloved!', href: 'mailto:raiseedinburgh@gmail.com'},
+					{text: 'Get Involved!', href: 'mailto:raiseedinburgh@gmail.com'},
 				]}
 			/>
 			<Section className='px-8'>

--- a/apps/web/src/pages/ucl/index.tsx
+++ b/apps/web/src/pages/ucl/index.tsx
@@ -30,7 +30,7 @@ const IndexPage = () => (
 				]}
 				right={[
 					{text: 'Donate', href: 'donate/'},
-					{text: 'Get Invloved!', href: 'mailto:raiseucl@gmail.com'},
+					{text: 'Get Involved!', href: 'mailto:raiseucl@gmail.com'},
 				]}
 			/>
 			<Section className='px-8'>

--- a/apps/web/src/pages/warwick/index.tsx
+++ b/apps/web/src/pages/warwick/index.tsx
@@ -21,7 +21,7 @@ const IndexPage = () => (
 		<Cover>
 			<Navigation
 				left={[
-					{text: 'Home', href: '/warwick/'},
+					{text: 'Home', href: '/'},
 					{text: 'How It Works', href: '/warwick/#how-it-works'},
 					{text: 'FAQs', href: '/warwick/#faq'},
 					{text: 'Our Philosophy', href: '/warwick/#our-philosophy'},

--- a/apps/web/src/pages/workplace/index.tsx
+++ b/apps/web/src/pages/workplace/index.tsx
@@ -23,7 +23,7 @@ const IndexPage = () => (
 		<Cover>
 			<Navigation
 				left={[
-					{text: 'Home', href: '.'},
+					{text: 'Home', href: '/'},
 					{text: 'How It Works', href: '#how-it-works'},
 					{text: 'FAQs', href: '#faq'},
 					{text: 'Our Philosophy', href: '#our-philosophy'},


### PR DESCRIPTION
## Summary
Follow-up to #457:
- Set Home `href` to `/` on bristol, demo, warwick, and workplace (matching the convention adopted in #457).
- Fix the "Get Invloved!" typo on UCL and Edinburgh.

Cambridge (May Week Alternative) Home is intentionally left as-is. No `right` links added to bristol.

## Test plan
- [ ] Visit each chapter page (bristol, demo, warwick, workplace) and confirm the Home button navigates to `/`.
- [ ] Confirm UCL and Edinburgh now display "Get Involved!" (correct spelling).