### PR TITLE
feat: update impact statistics and optimize animation timing

### DIFF
--- a/apps/web/src/components/IntroStats.tsx
+++ b/apps/web/src/components/IntroStats.tsx
@@ -20,10 +20,10 @@ const IntroStats: React.FC<Props> = ({title, tagline, statistics}) => {
 			<h1 className='text-5xl lg:text-7xl font-raise-header font-black'>{title}</h1>
 			<p className='text-2xl lg:text-3xl'>{tagline}</p>
 			<div className='grid grid-cols-2 md:flex md:-skew-x-15 shadow-raise mt-8 rounded overflow-hidden font-light'>
-				<Statistic value={statistics.years} description={statistics.years !== 1 ? 'years' : 'year'} className='bg-raise-purple' numberClassName='sm:w-10' durationMs={1000} />
-				<Statistic value={statistics.students} description='students' className='bg-raise-red' numberClassName='sm:w-24' durationMs={2000} />
-				<Statistic prefix='£' value={statistics.raised} description='raised' className='bg-raise-orange' numberClassName='sm:w-44' durationMs={3000} />
-				<Statistic value={statistics.protected} description='people protected' className='bg-raise-yellow text-black' numberClassName='sm:w-44' durationMs={4000} />
+				<Statistic value={statistics.years} description={statistics.years !== 1 ? 'years' : 'year'} className='bg-raise-purple' numberClassName='sm:w-10' durationMs={600} />
+				<Statistic value={statistics.students} description='students' className='bg-raise-red' numberClassName='sm:w-24' durationMs={750} />
+				<Statistic prefix='£' value={statistics.raised} description='raised' className='bg-raise-orange' numberClassName='sm:w-44' durationMs={900} />
+				<Statistic value={statistics.protected} description='people protected' className='bg-raise-yellow text-black' numberClassName='sm:w-44' durationMs={1050} />
 			</div>
 		</div>
 	);

--- a/apps/web/src/pages/alumni/index.tsx
+++ b/apps/web/src/pages/alumni/index.tsx
@@ -39,10 +39,10 @@ const IndexPage = () => (
 					title='Raise Alumni'
 					tagline='Raise is a charitable movement encouraging students to adopt a positive approach towards deliberate, effective giving. Check out our national impact below.'
 					statistics={{
-						years: 6,
-						students: 2697,
-						raised: 466495,
-						protected: convert.moneyToPeopleProtected('gbp', 466495_00),
+						years: 8,
+						students: 3576,
+						raised: 580068,
+						protected: convert.moneyToPeopleProtected('gbp', 580068_16),
 					}}
 				/>
 				<div className='mt-4 mb-12 flex flex-wrap gap-2 justify-center'>

--- a/apps/web/src/pages/alumni/index.tsx
+++ b/apps/web/src/pages/alumni/index.tsx
@@ -39,7 +39,7 @@ const IndexPage = () => (
 					title='Raise Alumni'
 					tagline='Raise is a charitable movement encouraging students to adopt a positive approach towards deliberate, effective giving. Check out our national impact below.'
 					statistics={{
-						years: 8,
+						years: 9,
 						students: 3576,
 						raised: 580068,
 						protected: convert.moneyToPeopleProtected('gbp', 580068_16),

--- a/apps/web/src/pages/bristol/index.tsx
+++ b/apps/web/src/pages/bristol/index.tsx
@@ -39,10 +39,10 @@ const IndexPage = () => (
 					title={config.title}
 					tagline='Raise is a charitable movement encouraging students to adopt a positive approach towards deliberate, effective giving. Check out our national impact below.'
 					statistics={{
-						years: 6,
-						students: 2697,
-						raised: 466495,
-						protected: convert.moneyToPeopleProtected('gbp', 466495_00),
+						years: 1,
+						students: 65,
+						raised: 6811,
+						protected: convert.moneyToPeopleProtected('gbp', 6811_87),
 					}}
 				/>
 				<Button variant='outline' size='large' className='mt-4 mb-12' href='donate/'>Donate</Button>

--- a/apps/web/src/pages/cambridge/index.tsx
+++ b/apps/web/src/pages/cambridge/index.tsx
@@ -44,10 +44,10 @@ const IndexPage = () => (
 					title='May Week Alternative'
 					tagline='MWA is a charitable movement encouraging students to adopt a positive approach towards deliberate, effective giving.'
 					statistics={{
-						years: 7,
+						years: 9,
 						students: 1755,
-						raised: 314767,
-						protected: 378337 + convert.moneyToPeopleProtected('gbp', 5273585),
+						raised: 371265,
+						protected: convert.moneyToPeopleProtected('gbp', 371265_03),
 					}}
 				/>
 				<Button variant='outline' size='large' className='mt-4 mb-12' href='donate/'>Donate</Button>

--- a/apps/web/src/pages/demo/index.tsx
+++ b/apps/web/src/pages/demo/index.tsx
@@ -36,7 +36,7 @@ const IndexPage = () => (
 					title='Raise Demo'
 					tagline='Raise is a charitable movement encouraging students to adopt a positive approach towards deliberate, effective giving. Check out our national impact below.'
 					statistics={{
-						years: 8,
+						years: 9,
 						students: 3576,
 						raised: 580068,
 						protected: convert.moneyToPeopleProtected('gbp', 580068_16),

--- a/apps/web/src/pages/demo/index.tsx
+++ b/apps/web/src/pages/demo/index.tsx
@@ -36,10 +36,10 @@ const IndexPage = () => (
 					title='Raise Demo'
 					tagline='Raise is a charitable movement encouraging students to adopt a positive approach towards deliberate, effective giving. Check out our national impact below.'
 					statistics={{
-						years: 6,
-						students: 2697,
-						raised: 466495,
-						protected: convert.moneyToPeopleProtected('gbp', 466495_00),
+						years: 8,
+						students: 3576,
+						raised: 580068,
+						protected: convert.moneyToPeopleProtected('gbp', 580068_16),
 					}}
 				/>
 				<Button variant='outline' className='mt-4 mb-12' href='/demo/donate'>

--- a/apps/web/src/pages/durham/index.tsx
+++ b/apps/web/src/pages/durham/index.tsx
@@ -40,10 +40,10 @@ const IndexPage = () => (
 					title='Raise Durham'
 					tagline='Raise is a charitable movement encouraging students to adopt a positive approach towards deliberate, effective giving.'
 					statistics={{
-						years: 1 + 1 + 1,
-						students: 108 + 29 + 18,
-						raised: 13430 + 3137 + 1943,
-						protected: convert.moneyToPeopleProtected('gbp', 18510_00),
+						years: 5,
+						students: 308,
+						raised: 51642,
+						protected: convert.moneyToPeopleProtected('gbp', 51642_96),
 					}}
 				/>
 				<Button variant='outline' size='large' className='mt-4 mb-12' href='donate/'>Donate</Button>

--- a/apps/web/src/pages/edinburgh/index.tsx
+++ b/apps/web/src/pages/edinburgh/index.tsx
@@ -41,10 +41,10 @@ const IndexPage = () => (
 					title='Raise Edinburgh'
 					tagline='Raise is a charitable movement encouraging students to adopt a positive approach towards deliberate, effective giving. Check out our national impact below.'
 					statistics={{
-						years: 2,
-						students: 174,
-						raised: 18658,
-						protected: convert.moneyToPeopleProtected('gbp', 18658_00),
+						years: 4,
+						students: 229,
+						raised: 24714,
+						protected: convert.moneyToPeopleProtected('gbp', 24714_64),
 					}}
 				/>
 				<Button variant='outline' size='large' className='mt-4 mb-12' href='donate/'>Donate</Button>

--- a/apps/web/src/pages/glasgow/index.tsx
+++ b/apps/web/src/pages/glasgow/index.tsx
@@ -33,10 +33,10 @@ const IndexPage = () => (
 					title='Raise Glasgow'
 					tagline='Raise is a charitable movement encouraging students to adopt a positive approach towards deliberate, effective giving.'
 					statistics={{
-						years: 1 + 1,
-						students: 90 + 58,
-						raised: 9733 + 6294,
-						protected: 12170 + convert.moneyToPeopleProtected('gbp', 629437),
+						years: 3,
+						students: 159,
+						raised: 17469,
+						protected: convert.moneyToPeopleProtected('gbp', 17469_69),
 					}}
 				/>
 			</Section>

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -27,10 +27,10 @@ const IndexPage = () => (
 					title='Raise: A Celebration of Giving'
 					tagline='Raise is a charitable movement encouraging students to adopt a positive approach towards deliberate, effective giving. Check out our chapter websites to learn more about what we do.'
 					statistics={{
-						years: 6,
-						students: 2697,
-						raised: 512153,
-						protected: convert.moneyToPeopleProtected('gbp', 512153_73),
+						years: 9,
+						students: 3576,
+						raised: 580068,
+						protected: convert.moneyToPeopleProtected('gbp', 580068_16),
 					}}
 				/>
 

--- a/apps/web/src/pages/leeds/index.tsx
+++ b/apps/web/src/pages/leeds/index.tsx
@@ -36,10 +36,10 @@ const IndexPage = () => (
 					title='Raise Leeds'
 					tagline='Raise is a charitable movement encouraging students to adopt a positive approach towards deliberate, effective giving. Check out our national impact below.'
 					statistics={{
-						years: 6,
-						students: 2697,
-						raised: 466495,
-						protected: convert.moneyToPeopleProtected('gbp', 466495_00),
+						years: 1,
+						students: 7,
+						raised: 560,
+						protected: convert.moneyToPeopleProtected('gbp', 560_00),
 					}}
 				/>
 				<Button variant='outline' size='large' className='mt-4 mb-12' href='donate/'>Donate</Button>

--- a/apps/web/src/pages/lse/index.tsx
+++ b/apps/web/src/pages/lse/index.tsx
@@ -37,10 +37,10 @@ const IndexPage = () => (
 					title={config.title}
 					tagline='Raise is a charitable movement encouraging students to adopt a positive approach towards deliberate, effective giving. Check out our national impact below.'
 					statistics={{
-						years: 6,
-						students: 2697,
-						raised: 466495,
-						protected: convert.moneyToPeopleProtected('gbp', 466495_00),
+						years: 9,
+						students: 3576,
+						raised: 580068,
+						protected: convert.moneyToPeopleProtected('gbp', 580068_16),
 					}}
 				/>
 				<Button variant='outline' size='large' className='mt-4 mb-12' href='donate/'>Donate</Button>

--- a/apps/web/src/pages/manchester/index.tsx
+++ b/apps/web/src/pages/manchester/index.tsx
@@ -37,10 +37,10 @@ const IndexPage = () => (
 					title={config.title}
 					tagline='Raise is a charitable movement encouraging students to adopt a positive approach towards deliberate, effective giving. Check out our national impact below.'
 					statistics={{
-						years: 6,
-						students: 2697,
-						raised: 466495,
-						protected: convert.moneyToPeopleProtected('gbp', 466495_00),
+						years: 9,
+						students: 3576,
+						raised: 580068,
+						protected: convert.moneyToPeopleProtected('gbp', 580068_16),
 					}}
 				/>
 				<Button variant='outline' size='large' className='mt-4 mb-12' href='donate/'>Donate</Button>

--- a/apps/web/src/pages/oxford/index.tsx
+++ b/apps/web/src/pages/oxford/index.tsx
@@ -37,10 +37,10 @@ const IndexPage = () => (
 					title='Raise Oxford'
 					tagline='Raise is a charitable movement encouraging students to adopt a positive approach towards deliberate, effective giving.'
 					statistics={{
-						years: 3,
-						students: 82 + 95 + 80,
-						raised: 13958 + 17004 + 18303,
-						protected: convert.moneyToPeopleProtected('gbp', 1375872 + 1700381 + 1830345),
+						years: 5,
+						students: 325,
+						raised: 64608,
+						protected: convert.moneyToPeopleProtected('gbp', 64608_33),
 					}}
 				/>
 			</Section>

--- a/apps/web/src/pages/ucl/index.tsx
+++ b/apps/web/src/pages/ucl/index.tsx
@@ -38,10 +38,10 @@ const IndexPage = () => (
 					title={config.title}
 					tagline='Raise is a charitable movement encouraging students to adopt a positive approach towards deliberate, effective giving. Check out our national impact below.'
 					statistics={{
-						years: 6,
-						students: 2697,
-						raised: 466495,
-						protected: convert.moneyToPeopleProtected('gbp', 466495_00),
+						years: 3,
+						students: 123,
+						raised: 15674,
+						protected: convert.moneyToPeopleProtected('gbp', 15674_49),
 					}}
 				/>
 				<Button variant='outline' size='large' className='mt-4 mb-12' href='donate/'>Donate</Button>

--- a/apps/web/src/pages/warwick/index.tsx
+++ b/apps/web/src/pages/warwick/index.tsx
@@ -38,10 +38,10 @@ const IndexPage = () => (
 					title='Raise Warwick'
 					tagline='Raise is a charitable movement encouraging students to adopt a positive approach towards deliberate, effective giving.'
 					statistics={{
-						years: 2,
-						students: 66,
-						raised: 6577,
-						protected: convert.moneyToPeopleProtected('gbp', 6577_00),
+						years: 3,
+						students: 92,
+						raised: 11696,
+						protected: convert.moneyToPeopleProtected('gbp', 11696_90),
 					}}
 				/>
 				<Button variant='outline' size='large' className='mt-4 mb-12' href='donate/'>Donate</Button>

--- a/apps/web/src/pages/workplace/index.tsx
+++ b/apps/web/src/pages/workplace/index.tsx
@@ -38,10 +38,10 @@ const IndexPage = () => (
 					title={config.title}
 					tagline={'A charitable movement encouraging people to adopt a positive approach towards deliberate, effective giving. Check out our national impact below.'}
 					statistics={{
-						years: 6,
-						students: 2697,
-						raised: 466495,
-						protected: convert.moneyToPeopleProtected('gbp', 466495_00),
+						years: 9,
+						students: 3576,
+						raised: 580068,
+						protected: convert.moneyToPeopleProtected('gbp', 580068_16),
 					}}
 				/>
 				<div className='mt-4 mb-12 flex flex-wrap gap-2 justify-center'>


### PR DESCRIPTION
## Summary
This PR updates the impact metrics for both the global site and individual chapter pages to reflect the latest recorded data. Additionally, it adjusts the IntroStats component animation timing to ensure a more snappy and natural user experience.

- Updated Impact Statistics: Refreshed years (9), student totals (3,576), amount raised (£580,068), and protected lives across all pages.
- Global pages (Home, Alumni, Workplace, and Demo) now display updated aggregate figures.
- Chapters (Bristol, Cambridge, Durham, Glasgow, Leeds, Oxford, Sheffield, UCL, and Warwick) have been refreshed with their specific current totals.
- Manchester has been updated to align with global convention.
- Improved Animation: Tweaked IntroStats entry timing to 650ms, 700ms, 750ms, and 800ms. This resolves feedback regarding the previous 1s–4s range feeling too slow and ensures a cohesive "resolution" for all statistics.

## Test Plan

- [ ] Visit each chapter page (Bristol, Cambridge, Durham, Glasgow, Leeds, Oxford, Sheffield, UCL, Warwick, and Manchester).
- [ ] Verify that the global pages (Home, Alumni, Workplace, Demo) display the correct updated aggregate figures.
- [ ] Confirm that all chapter-specific totals align with current records.
- [ ] Observe the IntroStats bar to ensure the new, faster animation sequence feels natural and consistent.