### PR TITLE
fix(ci): use @raise/web package name in turbo --filter for Turbo 2.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,4 +47,4 @@ jobs:
       # Deployment to prod environment
       - name: "web: Deploy to prod environment"
         if: github.ref == 'refs/heads/master'
-        run: npx turbo deploy:prod --filter web
+        run: npx turbo deploy:prod --filter @raise/web

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Summary: start everything with `npx turbo start`, and test with `npx turbo test`
 | `npx turbo deploy:dev`  | Deploy to dev environment                      |
 | `npx turbo deploy:prod` | Deploy to prod environment                     |
 
-All commands are run from the root of the repository. Any of the turbo commands can be filtered with `--filter <app>`, for example to start just `web` run `npx turbo start --filter web`
+All commands are run from the root of the repository. Any of the turbo commands can be filtered with `--filter <app>`, for example to start just `web` run `npx turbo start --filter @raise/web`
 
 These scripts are defined in the relevant `package.json` files. We keep these scripts as simple to use as possible, so developers need to run very few commands. We also keep these scripts consistent so that they behave as expected across the repo, and we need less config overrides.
 


### PR DESCRIPTION
## Problem

Master CI has been failing since #465 bumped turbo `1.11.3` -> `2.9.14`. The `test`/`lint`/`build` tasks and the `deploy:dev` step all pass, but the final step fails:

```
npx turbo deploy:prod --filter web
  x No package found with name 'web' in workspace
```

This is a Turbo 2.x breaking change: `--filter` now matches against the **package.json `name`** rather than the directory/partial name. Our web package is named `@raise/web`, so `--filter web` no longer matches.

(The other Turbo 2.x migration bits — `turbo.json` `pipeline`->`tasks` and the `$schema` — were already in place on master.)

## Fix

- `.github/workflows/ci.yaml`: `--filter web` -> `--filter @raise/web`
- `README.md`: update the documented `--filter` example to match

## Verification

Reproduced locally with turbo 2.9.14:
- `npx turbo deploy:prod --filter web` -> "No package found with name 'web'"
- `npx turbo deploy:prod --filter @raise/web` -> resolves to 1 package, task `@raise/web#deploy:prod` found
- `npx turbo test lint build` -> 10 successful, 10 total

🤖 Generated with [Claude Code](https://claude.com/claude-code)