### PR TITLE
fix: use @raise/web package name in turbo deploy:prod filter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,4 +47,4 @@ jobs:
       # Deployment to prod environment
       - name: "web: Deploy to prod environment"
         if: github.ref == 'refs/heads/master'
-        run: npx turbo deploy:prod --filter web
+        run: npx turbo deploy:prod --filter @raise/web


### PR DESCRIPTION
## Problem

Master CI has been failing since #465 bumped turbo 1.11.3 -> 2.9.14. The `build` job's final step, `web: Deploy to prod environment`, fails immediately with:

```
x No package found with name 'web' in workspace
```

The `test lint build` and `deploy:dev` steps pass because they don't use `--filter`. (The `turbo.json` `pipeline` -> `tasks` rename was already handled in #465.)

## Cause

Turbo 2.x changed `--filter` to match against the package `name` field in `package.json` rather than the workspace directory name. The web app is named `@raise/web`, so `--filter web` no longer resolves.

## Fix

Change the prod-deploy filter to `--filter @raise/web`.

Verified locally with turbo 2.9.14:
- `npx turbo deploy:prod --filter web` -> `No package found with name 'web'`
- `npx turbo deploy:prod --filter @raise/web --dry-run` -> resolves `@raise/web` at `apps/web` and queues `@raise/web#deploy:prod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)