### PR TITLE
Migrate CI deploy auth from static AWS keys to GitHub OIDC

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,10 @@ on:
       - master
   pull_request:
 
+permissions:
+  id-token: write   # mint the GitHub OIDC token used to assume the AWS role
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-24.04
@@ -26,13 +30,15 @@ jobs:
       - name: Test, lint, build
         run: npx turbo test lint build
 
-      # Deployment prep
-      - name: "Configure for deployment"
+      # Deployment prep — AWS access via GitHub OIDC federation (no stored keys).
+      # Assumes the raise-ci role, which trusts this repo's master-ref OIDC token
+      # and grants the same serverless-policy the old static-key user had.
+      - name: "Configure AWS credentials (OIDC)"
         if: github.ref == 'refs/heads/master'
-        run: npm run config:aws --workspace @raise/server
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::405129592067:role/raise-ci
+          aws-region: eu-west-1
 
       # Deployment to dev environment
       - name: "server: Retrieve env for dev environment"

--- a/apps/server/serverless.ts
+++ b/apps/server/serverless.ts
@@ -8,6 +8,12 @@ import {getFunctionEvent, getFunctionPaths, pascalCase} from './local/helpers';
 
 const SERVICE_NAME = 'raise-server';
 
+// Locally, deploy with the named profile (static keys in ~/.aws). In CI we
+// authenticate via GitHub OIDC (the raise-ci role), which puts credentials in
+// the environment — so leave `profile` unset there to use the default chain,
+// as a named profile would otherwise override the assumed-role credentials.
+const AWS_PROFILE = process.env.AWS_ACCESS_KEY_ID ? undefined : 'raise-405129592067';
+
 const createResources = (definitions: Record<string, Table<any, any, any>>): NonNullable<NonNullable<AWS['resources']>['Resources']> =>
 	Object.values(definitions).reduce<NonNullable<NonNullable<AWS['resources']>['Resources']>>((acc, table) => {
 		const resourceKey = `${pascalCase(table.entityName)}Table`;
@@ -150,7 +156,7 @@ const serverlessConfiguration: AWS = {
 		name: 'aws',
 		runtime: 'nodejs18.x',
 		region: 'eu-west-1',
-		profile: 'raise-405129592067',
+		profile: AWS_PROFILE,
 		stage: env.STAGE,
 		apiGateway: {
 			minimumCompressionSize: 1024,


### PR DESCRIPTION
## What

Replaces the long-lived AWS access-key pair used by CI (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, the `serverless` IAM user) with **GitHub OIDC federation** — the same pattern used elsewhere. CI now assumes a `raise-ci` role via a short-lived, repo+branch-scoped OIDC token; no stealable standing keys.

## Changes

- **`.github/workflows/ci.yaml`**: add `id-token: write` permission; replace the `config:aws` static-key step with `aws-actions/configure-aws-credentials@v4` assuming `raise-ci`.
- **`apps/server/serverless.ts`**: only set the named `profile` when env credentials aren't already present. In CI, `configure-aws-credentials` puts the assumed-role creds in the environment, and a named `profile` would otherwise override them. **Local dev is unchanged** — `npm run config:aws` + the `raise-405129592067` profile still work exactly as before.

## AWS side (already provisioned in account 405129592067)

- GitHub OIDC identity provider `token.actions.githubusercontent.com` (audience `sts.amazonaws.com`).
- Role **`raise-ci`** with a trust policy scoped to `repo:raisenational/raise:ref:refs/heads/master`, and the existing **`serverless-policy`** attached (identical permissions to the old user — no broader grant).

## After merge

- The deploy runs on `master` and exercises the OIDC path (it can only be validated on master, since the role's trust is scoped to the master ref).
- Once green, the old `serverless` IAM user's access keys can be deactivated (they're also used by the optional local `config:aws` dev flow, so they'll be kept, just disabled/rotated separately). The `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` repo secrets are then unused and can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)