### PR TITLE
Fix OIDC deploy: gate serverless profile on GITHUB_ACTIONS

### DIFF
--- a/apps/server/serverless.ts
+++ b/apps/server/serverless.ts
@@ -8,11 +8,12 @@ import {getFunctionEvent, getFunctionPaths, pascalCase} from './local/helpers';
 
 const SERVICE_NAME = 'raise-server';
 
-// Locally, deploy with the named profile (static keys in ~/.aws). In CI we
-// authenticate via GitHub OIDC (the raise-ci role), which puts credentials in
-// the environment — so leave `profile` unset there to use the default chain,
-// as a named profile would otherwise override the assumed-role credentials.
-const AWS_PROFILE = process.env.AWS_ACCESS_KEY_ID ? undefined : 'raise-405129592067';
+// Locally, deploy with the named profile (static keys in ~/.aws). In CI (GitHub
+// Actions) we authenticate via GitHub OIDC (the raise-ci role) and use the
+// default credential chain, so leave `profile` unset. Gate on GITHUB_ACTIONS,
+// not the AWS creds: this config is evaluated at `serverless package` (build)
+// time, which runs before the OIDC step sets AWS_ACCESS_KEY_ID.
+const AWS_PROFILE = process.env.GITHUB_ACTIONS ? undefined : 'raise-405129592067';
 
 const createResources = (definitions: Record<string, Table<any, any, any>>): NonNullable<NonNullable<AWS['resources']>['Resources']> =>
 	Object.values(definitions).reduce<NonNullable<NonNullable<AWS['resources']>['Resources']>>((acc, table) => {

--- a/apps/web/serverless.ts
+++ b/apps/web/serverless.ts
@@ -6,6 +6,13 @@ const MWA_SERVICE_NAME = 'mwa-website';
 const RAISE_S3_BUCKET_NAME = `${RAISE_SERVICE_NAME}-${env.STAGE}-405129592067`;
 const MWA_S3_BUCKET_NAME = `${MWA_SERVICE_NAME}-${env.STAGE}-405129592067`;
 
+// Locally, deploy with the named profile (static keys in ~/.aws). In CI (GitHub
+// Actions) we authenticate via GitHub OIDC (the raise-ci role) and use the
+// default credential chain, so leave `profile` unset. Gate on GITHUB_ACTIONS,
+// not the AWS creds: this config is evaluated at `serverless package` (build)
+// time, which runs before the OIDC step sets AWS_ACCESS_KEY_ID.
+const AWS_PROFILE = process.env.GITHUB_ACTIONS ? undefined : 'raise-405129592067';
+
 const serverlessConfiguration: AWS = {
 	service: RAISE_SERVICE_NAME,
 	frameworkVersion: '3',
@@ -40,7 +47,7 @@ const serverlessConfiguration: AWS = {
 		runtime: 'nodejs22.x',
 		region: 'eu-west-1',
 		stage: env.STAGE,
-		profile: 'raise-405129592067',
+		profile: AWS_PROFILE,
 	},
 	resources: {
 		Resources: {


### PR DESCRIPTION
Follow-up to #479. The OIDC migration left `master` deploys failing:

```
× Stack raise-server-dev failed to deploy
AWS profile "raise-405129592067" doesn't seem to be configured
```

## Cause

`serverless.ts` gated the named `profile` on `AWS_ACCESS_KEY_ID` being present. But the config is evaluated at **`serverless package` (build) time** — which runs in the "Test, lint, build" step, **before** the "Configure AWS credentials (OIDC)" step sets the AWS creds. So `AWS_ACCESS_KEY_ID` was still unset at evaluation, the named profile got baked in, and the later deploy failed trying to use it.

## Fix

Gate on **`GITHUB_ACTIONS`** (set for the entire job, build included) instead of the AWS creds. In CI the profile is omitted and serverless uses the OIDC default credential chain; locally it still uses the named profile. Applied to **both** `apps/server/serverless.ts` and `apps/web/serverless.ts` (web still hardcoded the profile and would fail identically on `deploy:prod`).

Both workspaces build clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)