### PR TITLE
Pass AWS_* env through turbo to deploy tasks (fixes OIDC creds)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You only need to do this once.
 3. Clone the repository ([more info](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository))
 4. Open the folder with VS Code
 5. Run `npm install` in the root
-6. (Optional, only if you need to deploy) Run `AWS_ACCESS_KEY_ID=AKIA... AWS_SECRET_ACCESS_KEY=... npm run config:aws --workspace @raise/server`
+6. (Optional, only if you need to deploy locally) Set up AWS credentials for the account, e.g. `AWS_ACCESS_KEY_ID=AKIA... AWS_SECRET_ACCESS_KEY=... npm run config:aws --workspace @raise/server`, then deploy with that profile selected: `AWS_PROFILE=raise-405129592067 npx turbo deploy:dev`. (CI deploys automatically on `master` via GitHub OIDC — no keys needed.)
 
 ### 🏃 Running locally
 

--- a/apps/server/serverless.ts
+++ b/apps/server/serverless.ts
@@ -8,13 +8,6 @@ import {getFunctionEvent, getFunctionPaths, pascalCase} from './local/helpers';
 
 const SERVICE_NAME = 'raise-server';
 
-// Locally, deploy with the named profile (static keys in ~/.aws). In CI (GitHub
-// Actions) we authenticate via GitHub OIDC (the raise-ci role) and use the
-// default credential chain, so leave `profile` unset. Gate on GITHUB_ACTIONS,
-// not the AWS creds: this config is evaluated at `serverless package` (build)
-// time, which runs before the OIDC step sets AWS_ACCESS_KEY_ID.
-const AWS_PROFILE = process.env.GITHUB_ACTIONS ? undefined : 'raise-405129592067';
-
 const createResources = (definitions: Record<string, Table<any, any, any>>): NonNullable<NonNullable<AWS['resources']>['Resources']> =>
 	Object.values(definitions).reduce<NonNullable<NonNullable<AWS['resources']>['Resources']>>((acc, table) => {
 		const resourceKey = `${pascalCase(table.entityName)}Table`;
@@ -157,7 +150,6 @@ const serverlessConfiguration: AWS = {
 		name: 'aws',
 		runtime: 'nodejs18.x',
 		region: 'eu-west-1',
-		profile: AWS_PROFILE,
 		stage: env.STAGE,
 		apiGateway: {
 			minimumCompressionSize: 1024,

--- a/apps/web/serverless.ts
+++ b/apps/web/serverless.ts
@@ -6,13 +6,6 @@ const MWA_SERVICE_NAME = 'mwa-website';
 const RAISE_S3_BUCKET_NAME = `${RAISE_SERVICE_NAME}-${env.STAGE}-405129592067`;
 const MWA_S3_BUCKET_NAME = `${MWA_SERVICE_NAME}-${env.STAGE}-405129592067`;
 
-// Locally, deploy with the named profile (static keys in ~/.aws). In CI (GitHub
-// Actions) we authenticate via GitHub OIDC (the raise-ci role) and use the
-// default credential chain, so leave `profile` unset. Gate on GITHUB_ACTIONS,
-// not the AWS creds: this config is evaluated at `serverless package` (build)
-// time, which runs before the OIDC step sets AWS_ACCESS_KEY_ID.
-const AWS_PROFILE = process.env.GITHUB_ACTIONS ? undefined : 'raise-405129592067';
-
 const serverlessConfiguration: AWS = {
 	service: RAISE_SERVICE_NAME,
 	frameworkVersion: '3',
@@ -47,7 +40,6 @@ const serverlessConfiguration: AWS = {
 		runtime: 'nodejs22.x',
 		region: 'eu-west-1',
 		stage: env.STAGE,
-		profile: AWS_PROFILE,
 	},
 	resources: {
 		Resources: {

--- a/turbo.json
+++ b/turbo.json
@@ -18,10 +18,12 @@
       "outputs": ["dist", ".serverless", ".next/**", "!.next/cache/**"]
     },
     "deploy:dev": {
-      "cache": false
+      "cache": false,
+      "passThroughEnv": ["AWS_*"]
     },
     "deploy:prod": {
-      "cache": false
+      "cache": false,
+      "passThroughEnv": ["AWS_*"]
     }
   }
 }


### PR DESCRIPTION
**This is the actual fix** for the "AWS provider credentials not found" CI deploy failures (the profile/osls PRs #480–#482 were necessary cleanups but not the cause).

## Root cause
Turbo sandboxes each task's environment. The `deploy:dev`/`deploy:prod` tasks didn't declare `passThroughEnv`, so the `AWS_*` credentials that `configure-aws-credentials` (OIDC) sets in the job environment were **stripped by turbo** before `serverless deploy` ran — hence serverless saw no credentials.

## Fix
Add `passThroughEnv: ["AWS_*"]` to both deploy tasks, matching the working `odir` repo's `turbo.json`.

With this + osls (#482) + no hardcoded profile (#481), raise now matches odir's proven OIDC deploy setup exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)