### PR TITLE
CI: node24-compatible actions + working turbo cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,16 +17,21 @@ jobs:
 
     steps:
       - name: Checkout ${{ github.sha }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
-      - name: Set up Turborepo caching
-        uses: dtinth/setup-github-actions-caching-for-turbo@v1
+      - name: Cache Turborepo
+        uses: actions/cache@v4
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-
       - name: Test, lint, build
         run: npx turbo test lint build
 


### PR DESCRIPTION
Two CI cleanups (both surfaced while working on the OIDC migration).

## 1. Node 20 deprecation warning
`actions/checkout@v3` and `actions/setup-node@v3` target the deprecated Node 20 runtime. Bumped both to `@v4` (Node 24-compatible), matching the odir repo.

## 2. Turbo remote caching was silently broken
The `dtinth/setup-github-actions-caching-for-turbo@v1` action logged `Remote caching unavailable (Could not connect to "http://localhost:41230")` under Turbo 2.x, so **every task was a cache miss** — the caching did nothing. (The action is experimental/unmaintained and this affects odir too.)

Replaced it with the official **`actions/cache@v4`** on Turbo's local `.turbo/cache` directory, with `restore-keys` for cross-run partial restore. Real cache hits will appear from the second run onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)